### PR TITLE
Fix config so tests work after fresh git clone

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
 	"scripts": {
 		"dts": "npx npm-dts generate -o ./build/index.d.ts",
 		"prepare": "npm run build",
-		"test": "jest --verbose false",
-		"build": "tsc --project tsconfig.json && tscpaths -p tsconfig.json -s ./source -o ./build",
+		"test": "jest --verbose false --roots ./tests",
+		"build": "tsc --project tsconfig.build.json && tscpaths -p tsconfig.build.json -s ./source -o ./build",
 		"dev": "nodemon -r tsconfig-paths/register sample/index.ts"
 	},
 	"author": "Luis Gazcón",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,4 +1,4 @@
 {
 	"extends": "./tsconfig.json",
-	"exclude": ["node_modules", "tests", "dist", "**/*test.ts"]
+	"exclude": ["node_modules", "tests", "build", "**/*test.ts"]
 }

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,3 @@
+{
+	"extends": "./tsconfig.json"
+}


### PR DESCRIPTION
After cloning the repo I was unable to run tests for a few reasons:
- jest config requires `tsconfig.test.json` - but it didn't exist
- test files were getting compiled by tsc; the compiled versions don't work
- build folder hierarchy was wrong (compared to published npm package)

This PR has some small config changes to fix this.